### PR TITLE
Fix output formatting in file list

### DIFF
--- a/cmd/sokoni/main.go
+++ b/cmd/sokoni/main.go
@@ -19,6 +19,6 @@ func main() {
 
 	fmt.Printf("Found %d PDF files:\n", len(files))
 	for _, f := range files {
-		fmt.Printf("- %s (%d bytes)=\n", f.Path, f.Size)
+		fmt.Printf("- %s (%d bytes)\n", f.Path, f.Size)
 	}
 }


### PR DESCRIPTION
## Summary
- correct the file listing output line in `cmd/sokoni/main.go`

## Testing
- `go test ./...` *(fails: missing go.sum entry for external modules)*

------
https://chatgpt.com/codex/tasks/task_e_68436ed42c588332bfeaa1cfb1e0f3d9